### PR TITLE
PF4 components docs redirects to their page

### DIFF
--- a/src/editor-demo/common/example-common.js
+++ b/src/editor-demo/common/example-common.js
@@ -174,7 +174,7 @@ class ComponentExample extends Component {
 
   }
   render () {
-    const { value, parsedSchema, linkText, ContentText, activeMapper } = this.state;
+    const { value, parsedSchema, linkText, ContentText, activeMapper, component } = this.state;
     const frameContents = {
       pf3: {
         head: <link key="1" rel="stylesheet" type="text/css" href="/vendor.css" onLoad={ () => {
@@ -305,7 +305,7 @@ class ComponentExample extends Component {
           </Typography>
         </Grid>
         <Grid item xs={ 12 } >
-          <ContentText activeMapper={ activeMapper } />
+          <ContentText activeMapper={ activeMapper } component={ component } />
         </Grid>
       </Grid>
     );

--- a/src/editor-demo/common/examples-definitions.js
+++ b/src/editor-demo/common/examples-definitions.js
@@ -1,6 +1,7 @@
 import { componentTypes, validatorTypes } from '@data-driven-forms/react-form-renderer';
 import GenericComponentText from './examples-texts/generic-mui-component';
 import TabsText from './examples-texts/tabs';
+import SubFormText from './examples-texts/sub-form';
 
 export const baseExamples = [{
   component: componentTypes.TEXT_FIELD,
@@ -262,7 +263,7 @@ export const baseExamples = [{
 {
   component: componentTypes.SUB_FORM,
   linkText: 'Subform',
-  ContentText: GenericComponentText,
+  ContentText: SubFormText,
   value: { fields: [{
     component: componentTypes.SUB_FORM,
     title: 'Subform',

--- a/src/editor-demo/common/examples-texts/generic-mui-component.js
+++ b/src/editor-demo/common/examples-texts/generic-mui-component.js
@@ -3,10 +3,34 @@ import Typography from '@material-ui/core/Typography';
 
 const docsLinks = {
   mui: 'https://material-ui.com/',
-  pf4: 'http://patternfly-react.surge.sh/patternfly-4/',
+  pf4: 'http://patternfly-react.surge.sh/patternfly-4/components/',
   pf3: 'http://patternfly-react.surge.sh/patternfly-3/index.html',
 };
 
-export default ({ activeMapper }) => <Typography>
-    This component also accepts all other original props, please see <a href={ docsLinks[activeMapper] }>here</a>!
-</Typography>;
+export default ({ activeMapper, component }) => {
+  if (activeMapper === 'pf4'){
+    switch (component){
+      case 'date-picker':
+        component = 'textinput';
+        break;
+      case 'select-field':
+        component = 'select';
+        break;
+      case 'switch-field':
+        component = 'switch';
+        break;
+      case 'textarea-field':
+        component = 'textarea';
+        break;
+      case 'text-field':
+        component = 'textinput';
+        break;
+      case 'time-picker':
+        component = 'textinput';
+        break;
+    }
+  }
+
+  return <Typography>
+    This component also accepts all other original props, please see <a href={ `${docsLinks[activeMapper]}${ activeMapper === 'pf4' ? component : '' }` }>here</a>!
+  </Typography>;};

--- a/src/editor-demo/common/examples-texts/sub-form.js
+++ b/src/editor-demo/common/examples-texts/sub-form.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import Typography from '@material-ui/core/Typography';
+
+export default () =>
+  <Typography>
+    This is a custom component.
+  </Typography>;

--- a/src/editor-demo/common/other-text/manageiq-components.js
+++ b/src/editor-demo/common/other-text/manageiq-components.js
@@ -63,7 +63,6 @@ By default, the value contains all options from the right side select. However, 
 <br />
 
 **1** In constructor/componentDidMount/elsewhere (where you fetch data) save these values into state:
-\`originalLeftValues: filterOptions(options, value)\`       // this helper extracts left values from options
 \`originalOptions: options\`
 \`originalRightValues: value\`
 
@@ -74,7 +73,7 @@ By default, the value contains all options from the right side select. However, 
 <br />
 
 **\`filterOptions(originalOptions, values.duallist)\`** to get all values on left \n
-**\`addedLeftValues(originalOptions, values.duallist, originalLeftValues)\`** to get added values to left select \n
+**\`filterOptions(values.duallist, originalOptions)\`** to get added values to left select \n
 **\`filterOptions(values.duallist, originalRightValues)\`** to get added values to right select \n
 **\`getKeys(values)\`** to get keys of values \n
 


### PR DESCRIPTION
**Description**

Links on PF4 components lead to their exact page on Patternfly documentation. :confetti_ball: 

Plus a little update of MiQ Components Docs. :cat2: 