### PR TITLE
Table of content

### DIFF
--- a/src/editor-demo/App.js
+++ b/src/editor-demo/App.js
@@ -7,6 +7,7 @@ import FormRendererPage from './pages/form-renderer-page';
 import Navigation from './common/examples-nav';
 import ComponentExample from './common/example-common';
 import DocPage from './common/doc-page';
+import ContributionPage from './pages/contribution';
 
 import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
@@ -55,6 +56,7 @@ const App = () => (
               <Route exact path="/component-example/:component" component={ ComponentExample } />
               <Route exact path="/renderer/:component" component={ DocPage } />
               <Route exact path="/others/:component" component={ DocPage } />
+              <Route exact path="/contribution" component={ ContributionPage } />
             </Switch>
           </Grid>
         </Grid>

--- a/src/editor-demo/common/doc-texts/component-mapping.js
+++ b/src/editor-demo/common/doc-texts/component-mapping.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactMarkdown from '../md-helper';
 import { layoutComponents } from '@data-driven-forms/react-form-renderer';
+import TableOfContent, { headerToId } from '../helpers/list-of-content';
 
 const getTypes = (firstLine, apostrohpe = false) =>
   Object
@@ -14,6 +15,8 @@ We also understand that writing form components from the scratch might not be ve
 
 Form renderer requires two different mappers. Layout mapper and Form  FieldsMapper.
 
+<a id="${headerToId('Layout mapper')}" />
+
 ### Layout mapper
 Component inside this mapper influence the layout of the form. Now compared to the Form Fields mapper, we have to be very strict because we cannot define our own elements. Layout mapper must contain these types components:
 
@@ -25,6 +28,8 @@ ${ getTypes('const layoutComponents = {', true) }
 \`\`\`
 
 LayoutMapper is just good old javascript object with keys from layoutComponents, and the values are just React components:
+
+<a id="${headerToId('FormWrapper')}" />
 
 #### FormWrapper
 
@@ -46,6 +51,8 @@ const MyForm = () => (
 )
 \`\`\`
 
+<a id="${headerToId('Button')}" />
+
 #### Button
 Button component will be used for your submit, reset and cancel buttons.
 
@@ -65,6 +72,8 @@ const layoutMapper = {
 }
 \`\`\`
 
+<a id="${headerToId('Col')}" />
+
 #### Col
 Col represents wrapper arround one Form Field (hence the name Col). It does not have to mirror bootstrap Col, which is just the name we have decided to go with. If you for instance don't need any Col (or other wrapping) component, and you are handling this inside the actual Field component, you can use \`<React.Fragment>\` component. This way you will not create any element in your DOM. On the other hand, it might be usefull to implement it as a container for your components. Because we can't possibly create layout that suit 100% of our use cases, we can use this wrapper to pass additional styles to field components.
 
@@ -75,6 +84,8 @@ const Col = ({ children }) => (
   <div className="form-row">{children}</div>
 )
 \`\`\`
+
+<a id="${headerToId('FormGroup')}" />
 
 #### FormGroup
 
@@ -88,6 +99,8 @@ const FormGroup = ({ children }) => (
 )
 \`\`\`
 
+<a id="${headerToId('ButtonGroup')}" />
+
 #### ButtonGroup
 Wrapper for your form buttons
 
@@ -99,8 +112,12 @@ const ButtonGroup = ({ children }) => (
 )
 \`\`\`
 
+<a id="${headerToId('Icon, Array Field Wrapper, Help Block')}" />
+
 #### Icon, Array Field Wrapper, Help Block
 TO DO when array field docs are done
+
+<a id="${headerToId('Putting it all together')}" />
 
 #### Putting it all together
 
@@ -118,6 +135,8 @@ const MyForm = () => (
   />
 )
 \`\`\`
+
+<a id="${headerToId('Form Fields mapper')}" />
 
 ### Form Fields mapper
 
@@ -176,6 +195,8 @@ const schema = {
 
 \`\`\`
 
+<a id="${headerToId('What about nesting?')}" />
+
 #### What about nesting?
 There might be a need to create something like a SubForm in your Forms. We made it possible, and there are two ways to do it.
 
@@ -226,4 +247,8 @@ const CustomSubForm = ({ formOptions, fields, ...rest }) => (
 FormOptions are passed to every field (default and custom). If you extend it, the child of the sub form will receive your modified formOptions. You can even change te rendering function if you wish.
 `;
 
-export default <ReactMarkdown source={ text } />;
+export default <React.Fragment>
+  <TableOfContent text= { text } />
+  <ReactMarkdown source={ text } />
+</React.Fragment>;
+

--- a/src/editor-demo/common/doc-texts/condition.js
+++ b/src/editor-demo/common/doc-texts/condition.js
@@ -115,6 +115,9 @@ condition: {
 // Foo = 'bar' => false
 \`\`\`
 
+## Clearing values
+
+If you need to clear values after switching fields, please see [here](/renderer/unmounting). 
 
 `;
 

--- a/src/editor-demo/common/doc-texts/condition.js
+++ b/src/editor-demo/common/doc-texts/condition.js
@@ -1,8 +1,11 @@
 import React from 'react';
 import ReactMarkdown from '../md-helper';
+import TableOfContent, { headerToId } from '../helpers/list-of-content';
 
 const text =  `
 You can show a field only if it meets a condition:
+
+<a id="${headerToId('Schema')}" />
 
 ### Schema
 
@@ -27,6 +30,7 @@ You can show a field only if it meets a condition:
 
 \`when\` - is name of field where the value is stored, **always required!**
 
+<a id="${headerToId('Conditions')}" />
 
 ### Conditions
 
@@ -115,10 +119,16 @@ condition: {
 // Foo = 'bar' => false
 \`\`\`
 
-## Clearing values
+<a id="${headerToId('Clearing values')}" />
+
+### Clearing values
 
 If you need to clear values after switching fields, please see [here](/renderer/unmounting). 
 
 `;
 
-export default <ReactMarkdown source={ text } />;
+export default <React.Fragment>
+  <TableOfContent text= { text } />
+  <ReactMarkdown source={ text } />
+</React.Fragment>;
+

--- a/src/editor-demo/common/doc-texts/field-provider.js
+++ b/src/editor-demo/common/doc-texts/field-provider.js
@@ -1,114 +1,130 @@
 import React from 'react';
 import ReactMarkdown from '../md-helper';
+import TableOfContent, { headerToId } from '../helpers/list-of-content';
 
 const text = `
-  React form renderer is using [react-final-form](https://github.com/final-form/react-final-form) for form state management.
-  Most of its features are not directly available for consistency and performance reasons. If you want to create any custom
-  components, you can access these features via **FieldProvider**.
+React form renderer is using [react-final-form](https://github.com/final-form/react-final-form) for form state management.
+Most of its features are not directly available for consistency and performance reasons. If you want to create any custom
+components, you can access these features via **FieldProvider**.
 
 
-  FieldProvider is a wrapper component around standard
-  [react-final-form Field component](https://github.com/final-form/react-final-form#field--reactcomponenttypefieldprops)
-  which adds additional methods that will help you to control your form state.
+FieldProvider is a wrapper component around standard
+[react-final-form Field component](https://github.com/final-form/react-final-form#field--reactcomponenttypefieldprops)
+which adds additional methods that will help you to control your form state.
 
-  ## Accessing FieldProvider
+<a id="${headerToId('Accessing FieldProvider')}" />
 
-  To use Fieldprovider, you first need to register a component to your component mapper.
-  You can read more about that in [Component mapping](/renderer/component-mapping).
+### Accessing FieldProvider
 
-  Each component will receive FieldProvider as a prop. Be aware that pre-defined component types are
-  automatically wrapped in FieldProvider. This is done to make it easier to create component mappers for
-  standard form components. List of standard components is avaiable [here](/renderer/form-schemas).
+To use Fieldprovider, you first need to register a component to your component mapper.
+You can read more about that in [Component mapping](/renderer/component-mapping).
 
-  ## Using FieldProvider
+Each component will receive FieldProvider as a prop. Be aware that pre-defined component types are
+automatically wrapped in FieldProvider. This is done to make it easier to create component mappers for
+standard form components. List of standard components is avaiable [here](/renderer/form-schemas).
 
-  1. Register component
+<a id="${headerToId('Using FieldProvider')}" />
 
-  \`\`\`jsx
-  import NewComponent from './new-component'
+### Using FieldProvider
 
-  const formFieldsMapper = {
-    'new-component': NewComponent
-  }
-  \`\`\`
+1. Register component
 
-  2. Implementation
+\`\`\`jsx
+import NewComponent from './new-component'
 
-  Next example shows simple input field with label and error message.
+const formFieldsMapper = {
+  'new-component': NewComponent
+}
+\`\`\`
 
-  \`\`\`jsx
-  import React from 'react';
+2. Implementation
 
-  const NewComponent = ({ FieldProvider, formOptions, name ...rest }) => (
-    <div>
-      <FieldProvider {...rest} name={name}>
-        {({ input, meta, ...props }) => {
-          return (
-            <div>
-              <label>{props.label}</label>
-              <input {...input} />
-              {meta.error && <label>{meta.error}</label>}
-            </div>
-          )
-        }}
-      </FieldProvider>
-    </div>
-  )
+Next example shows simple input field with label and error message.
 
-  export default NewComponent
-  \`\`\`
+\`\`\`jsx
+import React from 'react';
 
-  ## What are input and meta?
-  
-  ### Input
+const NewComponent = ({ FieldProvider, formOptions, name ...rest }) => (
+  <div>
+    <FieldProvider {...rest} name={name}>
+      {({ input, meta, ...props }) => {
+        return (
+          <div>
+            <label>{props.label}</label>
+            <input {...input} />
+            {meta.error && <label>{meta.error}</label>}
+          </div>
+        )
+      }}
+    </FieldProvider>
+  </div>
+)
 
-  Input is an object which contains methods that change form state. It contains these attributes:
-  
-  \`\`\`json
-  {
-    value: any, // any value of given form field. Its data type is based on field data type
-    name: string,// unique name of form field. Value will be accessible under this key in form state
-    onBlur: (event) => void, // function that should be triggered on field blur event
-    onChange: (value) => void, // function that changes value of field in formState. Should be called whenever you want to change value of field
-    onFocus: (event) => void, // function that should be triggered on field focus event
-  }
-  \`\`\`
+export default NewComponent
+\`\`\`
 
-  Every user interaction that updates field value in form state should also call \`input.onChange\` with correct value.
+<a id="${headerToId('What are input and meta?')}" />
 
-  ### Meta
+### What are input and meta?
 
-  Meta is a object which contains meta information about field with given name. There is a lot of information about every field.
-  [Full list is here](https://github.com/final-form/react-final-form#metaactive-boolean). These are commonly used meta informations
-  \`\`\`json
-  {
-    error: any, // whatever your validation function returns
-    pristine: bool, // true if the current value is === to the initial value, false if the values are !==.
-    dirty: bool, // opposite of pristine
-    touched: bool, //true if this field has ever gained and lost focus. false otherwise. Useful for knowing when to display error messages.
-    valid: bool //true if this field has no validation or submission errors. false otherwise.
-  }
-  \`\`\`
+<a id="${headerToId('Input')}" />
 
-  ## FormOptions
+#### Input
 
-  In addition to FieldProvider, every component will also receive prop \`formOptions\`.
-  This property contains a number of useful methods and attributes that will give you additional level of control
-  and informations about the formState.
+Input is an object which contains methods that change form state. It contains these attributes:
 
-  \`\`\`json
-  {
-    blur: (name) => void, // calls onBlur event on field with given name
-    change: (name, value) => void, // calls onChange event on field with given name
-    focus: (name) => void, // calls onFocus event on field with given name
-    getFieldState: (name) => object, // returns a state of given field, state contains input and meta information of field
-    getRegisteredFields: () => string[], // returns an array of field names that are rendered in DOM
-    getState: () => object, // returns an object with whole form state. More info https://github.com/final-form/final-form#formstate
-    pristine: bool, // true if the all field values is === to the initial values, false if the values are !==.
-    renderForm: (defaultSchema) => void, // function that is used by form renderer to render form fields defined by defaultSchema; can be used for schema nesting
-    valid: bool //true if all fields have no validation or submission errors. false otherwise.
-  }
-  \`\`\`
+\`\`\`json
+{
+  value: any, // any value of given form field. Its data type is based on field data type
+  name: string,// unique name of form field. Value will be accessible under this key in form state
+  onBlur: (event) => void, // function that should be triggered on field blur event
+  onChange: (value) => void, // function that changes value of field in formState. Should be called whenever you want to change value of field
+  onFocus: (event) => void, // function that should be triggered on field focus event
+}
+\`\`\`
+
+Every user interaction that updates field value in form state should also call \`input.onChange\` with correct value.
+
+<a id="${headerToId('Meta')}" />
+
+#### Meta
+
+Meta is a object which contains meta information about field with given name. There is a lot of information about every field.
+[Full list is here](https://github.com/final-form/react-final-form#metaactive-boolean). These are commonly used meta informations
+\`\`\`json
+{
+  error: any, // whatever your validation function returns
+  pristine: bool, // true if the current value is === to the initial value, false if the values are !==.
+  dirty: bool, // opposite of pristine
+  touched: bool, //true if this field has ever gained and lost focus. false otherwise. Useful for knowing when to display error messages.
+  valid: bool //true if this field has no validation or submission errors. false otherwise.
+}
+\`\`\`
+
+<a id="${headerToId('FormOptions')}" />
+
+### FormOptions
+
+In addition to FieldProvider, every component will also receive prop \`formOptions\`.
+This property contains a number of useful methods and attributes that will give you additional level of control
+and informations about the formState.
+
+\`\`\`json
+{
+  blur: (name) => void, // calls onBlur event on field with given name
+  change: (name, value) => void, // calls onChange event on field with given name
+  focus: (name) => void, // calls onFocus event on field with given name
+  getFieldState: (name) => object, // returns a state of given field, state contains input and meta information of field
+  getRegisteredFields: () => string[], // returns an array of field names that are rendered in DOM
+  getState: () => object, // returns an object with whole form state. More info https://github.com/final-form/final-form#formstate
+  pristine: bool, // true if the all field values is === to the initial values, false if the values are !==.
+  renderForm: (defaultSchema) => void, // function that is used by form renderer to render form fields defined by defaultSchema; can be used for schema nesting
+  valid: bool //true if all fields have no validation or submission errors. false otherwise.
+}
+\`\`\`
 `;
 
-export default <ReactMarkdown source={ text } />;
+export default <React.Fragment>
+  <TableOfContent text= { text } />
+  <ReactMarkdown source={ text } />
+</React.Fragment>;

--- a/src/editor-demo/common/doc-texts/form-schemas.js
+++ b/src/editor-demo/common/doc-texts/form-schemas.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactMarkdown from '../md-helper';
-import TableOfContent from '../helpers/list-of-content';
+import TableOfContent, { headerToId } from '../helpers/list-of-content';
 import { componentTypes } from '@data-driven-forms/react-form-renderer';
 
 const getTypes = () => Object.entries(componentTypes).reduce((acc, curr) => `${acc}\n  ${curr[0]}: '${curr[1]}',`,
@@ -14,7 +14,7 @@ With the intention to provide additional customization in the future. Currently 
 - ManageIQ schema
 - Mozilla json schema
 
-<a id="default-schema" />
+<a id="${headerToId('Default schema')}" />
 
 ### Default schema
 
@@ -54,6 +54,8 @@ const schema = {
 
 Example above shows definition of a very simple form with two form fields and a validation. We will now take a closer look at its attributes.
 
+<a id="${headerToId('default-schema-attributes')}" />
+
 #### default-schema-attributes
 
 |name|data type|
@@ -64,17 +66,25 @@ Example above shows definition of a very simple form with two form fields and a 
 
 Detailed descriptions of each attribute is below.
 
+<a id="${headerToId('title?: string')}" />
+
 #### title?: string
 
 Attribute defining form title.
+
+<a id="${headerToId('description?: string')}" />
 
 #### description?: string
 
 Attribute defining form description.
 
+<a id="${headerToId('fields: Array of Objects')}" />
+
 #### fields: Array of Objects
 
 Array that contains field definitions.
+
+<a id="${headerToId('Fields')}" />
 
 #### Fields
 
@@ -89,6 +99,8 @@ In human language, items of field array must be either objects, where each objec
 or array of objects, which are form fields as well. This rule allows the component to render all the fields in one cycle with minimal code branching.
 
 The structure of a single object is following:
+
+<a id="${headerToId('field attributes')}" />
 
 #### field attributes
 
@@ -125,6 +137,8 @@ const field = {
 Note that the field structure may vary based on your component implementation. There are few required attributes and most of 
 them do not have to match the given types. Most of them are based on used form components.
 
+<a id="${headerToId('component: string')}" />
+
 #### component: string
 
 Unique identifier of the component. Final component will be picked based on this key. There are several pre-defined constants 
@@ -141,13 +155,19 @@ componentTypes = {
 We are not limited by these component types. You can add your own type or use only few of them or combination of both. 
 More detailed explanation of how this impacts the rendered form [can be found here](#form-fields-mapper).
 
+<a id="${headerToId('name: string')}" />
+
 #### name: string
 
 This is traditional html5 name attribute for input elements.
 
+<a id="${headerToId('label')}" />
+
 #### label
 
 Label for form field. The type is based on your component definition.
+
+<a id="${headerToId('validate: Array? of Objects')}" />
 
 #### validate: Array? of Objects
 
@@ -227,6 +247,8 @@ const validate = [{
 \`\`\`
 Validation functions are triggered only when field has a value with exception of required validator.
 
+<a id="${headerToId('dataType: string?')}" />
+
 #### dataType: string?
 
 Adds field validation based on the value data type.
@@ -247,6 +269,8 @@ There are currently four defined data types:
 \`\`\`jsx
 ['integer', 'number', 'bool', 'string']
 \`\`\`
+
+<a id="${headerToId('assignFieldProvider: bool?')}" />
 
 #### assignFieldProvider: bool?
 
@@ -271,6 +295,8 @@ const wrappedComponents = [
 
 This wrapper will add necessary props to your component that will handle form state updates. It is reccomended to 
 read about field component in React Final Form docs. 
+
+<a id="${headerToId('condition: Object?')}" />
 
 #### condition: Object?
 
@@ -313,6 +339,8 @@ const fields = [{
 
 In example above, field \`Bar\` will appear when fields \`Foo\` value is \`Show bar field\`, \`true\`, \`123\` or \`Or now\`.
 
+<a id="${headerToId('Other attributes')}" />
+
 #### Other attributes
 
 Any other attributes will be passed to the component matching the \`component\` identifier.
@@ -342,7 +370,7 @@ const field = {
 Remember that the components define the interface. If your label is an image, pass the image source with isImage 
 flag maybe and handle rendering in the component.
 
-<a id="field-array-and-fixed-list" />
+<a id="${headerToId('Field array and Fixed list')}" />
 
 ### Field array and Fixed list
 

--- a/src/editor-demo/common/doc-texts/form-schemas.js
+++ b/src/editor-demo/common/doc-texts/form-schemas.js
@@ -1,21 +1,29 @@
 import React from 'react';
 import ReactMarkdown from '../md-helper';
+import TableOfContent from '../helpers/list-of-content';
 import { componentTypes } from '@data-driven-forms/react-form-renderer';
 
 const getTypes = () => Object.entries(componentTypes).reduce((acc, curr) => `${acc}\n  ${curr[0]}: '${curr[1]}',`,
   '//TEXTEAREA_FIELD and SELECT COMPONENT ARE DEPRECATED!\n  //Please use TEXTAREA and SELECT!');
 
 const text =  `
-There are currently 3 schema definitions you can use to define your forms. With the intention to provide additional customization in the future. Currently supported schemas are:
+There are currently 3 schema definitions you can use to define your forms. 
+With the intention to provide additional customization in the future. Currently supported schemas are:
 
 - Default-schema
 - ManageIQ schema
 - Mozilla json schema
 
-### Default schema
-This is the default schema that is used directly for rendering the form. All other schema types are parsed to this one. This gives the option to write your custom parser that transforms any of your existing definitions into the default one, and use this renderer.
+<a id="default-schema" />
 
-The default schema is also very extensible. There is only a few requirements for the format. Most of the attributes are meta information and their shape is based upon **your** form components.
+### Default schema
+
+This is the default schema that is used directly for rendering the form. 
+All other schema types are parsed to this one. This gives the option to write your custom parser that transforms any of your existing definitions 
+into the default one, and use this renderer.
+
+The default schema is also very extensible. There is only a few requirements for the format. 
+Most of the attributes are meta information and their shape is based upon **your** form components.
 
 \`\`\`jsx
 import { componentTypes, validatorTypes } from '@data-driven-forms/react-form-renderer';
@@ -47,6 +55,7 @@ const schema = {
 Example above shows definition of a very simple form with two form fields and a validation. We will now take a closer look at its attributes.
 
 #### default-schema-attributes
+
 |name|data type|
 |---|---|
 |\`title?\`| string|
@@ -56,28 +65,35 @@ Example above shows definition of a very simple form with two form fields and a 
 Detailed descriptions of each attribute is below.
 
 #### title?: string
+
 Attribute defining form title.
 
 #### description?: string
+
 Attribute defining form description.
 
 #### fields: Array of Objects
+
 Array that contains field definitions.
 
 #### Fields
-This is the main data structure that holds definitions of all of the form fields. It is designed to match React rendering process. It must follow this rule:
+
+This is the main data structure that holds definitions of all of the form fields. It is designed to match React rendering process. 
+It must follow this rule:
 
 \`\`\`jsx
 const fields = [{...}, [{...}, {...}], {...}, {...}, [[[{...}]]]]
 \`\`\`
 
-In human language, items of field array must be either objects, where each object represents one formField (React component), or array of objects, which are form fields as well. This rule allows the component to render all the fields in one cycle with minimal code branching.
+In human language, items of field array must be either objects, where each object represents one formField (React component), 
+or array of objects, which are form fields as well. This rule allows the component to render all the fields in one cycle with minimal code branching.
 
 The structure of a single object is following:
 
 #### field attributes
 
-There are listed all field (items of the \`fields\` array) attributes that are defined by the default schema. Any other attributes given to field object are automatically passed to the specified component.
+There are listed all field (items of the \`fields\` array) attributes that are defined by the default schema. 
+Any other attributes given to field object are automatically passed to the specified component.
 
 Detailed descriptions of each attribute is below.
 
@@ -106,10 +122,13 @@ const field = {
 }
 \`\`\`
 
-Note that the field structure may vary based on your component implementation. There are few required attributes and most of them do not have to match the given types. Most of them are based on used form components.
+Note that the field structure may vary based on your component implementation. There are few required attributes and most of 
+them do not have to match the given types. Most of them are based on used form components.
 
 #### component: string
-Unique identifier of the component. Final component will be picked based on this key. There are several pre-defined constants identifying the most common components for ManageIQ and Insights apps.
+
+Unique identifier of the component. Final component will be picked based on this key. There are several pre-defined constants 
+identifying the most common components for ManageIQ and Insights apps.
 
 \`\`\`jsx
 import { componentTypes } from '@data-driven-forms/react-form-renderer';
@@ -119,15 +138,19 @@ componentTypes = {
 }
 \`\`\`
 
-We are not limited by these component types. You can add your own type or use only few of them or combination of both. More detailed explanation of how this impacts the rendered form [can be found here](#form-fields-mapper).
+We are not limited by these component types. You can add your own type or use only few of them or combination of both. 
+More detailed explanation of how this impacts the rendered form [can be found here](#form-fields-mapper).
 
 #### name: string
+
 This is traditional html5 name attribute for input elements.
 
 #### label
+
 Label for form field. The type is based on your component definition.
 
 #### validate: Array? of Objects
+
 Array of validation definitions. These are limited by the form renderer (Might be configurable in future).
 
 If you want to use out of the box validation, you must use this format:
@@ -205,6 +228,7 @@ const validate = [{
 Validation functions are triggered only when field has a value with exception of required validator.
 
 #### dataType: string?
+
 Adds field validation based on the value data type.
 
 \`\`\`jsx
@@ -225,6 +249,7 @@ There are currently four defined data types:
 \`\`\`
 
 #### assignFieldProvider: bool?
+
 FieldProvider is just a fancy name for [Field component](https://github.com/final-form/react-final-form#field--reactcomponenttypefieldprops).
 
 Following component types are wrapped in the FieldProvider by default:
@@ -244,9 +269,11 @@ const wrappedComponents = [
 ];
 \`\`\`
 
-This wrapper will add necessary props to your component that will handle form state updates. It is reccomended to read about field component in React Final Form docs. 
+This wrapper will add necessary props to your component that will handle form state updates. It is reccomended to 
+read about field component in React Final Form docs. 
 
 #### condition: Object?
+
 Condition is used to define condition fields. For instance, field **A** should render only when field **B** has value **Foo**.
 
 \`\`\`jsx
@@ -312,10 +339,17 @@ const field = {
 }
 \`\`\`
 
-Remember that the components define the interface. If your label is an image, pass the image source with isImage flag maybe and handle rendering in the component.
+Remember that the components define the interface. If your label is an image, pass the image source with isImage 
+flag maybe and handle rendering in the component.
+
+<a id="field-array-and-fixed-list" />
 
 ### Field array and Fixed list
+
 TO DO add documentaion here
 `;
 
-export default <ReactMarkdown source={ text } />;
+export default <React.Fragment>
+  <TableOfContent text={ text } />
+  <ReactMarkdown source={ text } />
+</React.Fragment>;

--- a/src/editor-demo/common/doc-texts/installation.js
+++ b/src/editor-demo/common/doc-texts/installation.js
@@ -8,6 +8,12 @@ or
 \`\`\`console
 yarn add @data-driven-forms/react-form-renderer
 \`\`\`
+- 
+### Links to NPM
+- a) [React form renderer](https://www.npmjs.com/package/@data-driven-forms/react-form-renderer)
+- b) [Patternfly 3 mapper](https://www.npmjs.com/package/@data-driven-forms/pf3-component-mapper)
+- c) [Patternfly 4 mapper](https://www.npmjs.com/package/@data-driven-forms/pf4-component-mapper)
+- d) [MaterialUI mapper](https://www.npmjs.com/package/@data-driven-forms/mui-component-mapper)
 `;
 
 export default <ReactMarkdown source={ text } />;

--- a/src/editor-demo/common/doc-texts/unmounting.js
+++ b/src/editor-demo/common/doc-texts/unmounting.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import ReactMarkdown from '../md-helper';
+
+const text =  `
+**Description**
+
+When using dynamic forms where more fields share the same name, the value is preserved when a user switch the field. You can disable this behavior by setting 
+\`clearOnUnmount\` option in the renderer component or in the schema of the field. The option in the schema has always higher priority. (When 
+\`clearOnUnmount\` is set in the renderer and the field is set to \`false\`, the field value will not be cleared.)
+
+**Examples**
+
+Renderer
+
+\`\`\`jsx
+<FormRenderer
+  layoutMapper={ layoutMapper }
+  formFieldsMapper={ formFieldsMapper }
+  schema={ schema }
+  onSubmit={ submit }
+  clearOnUnmount
+/>
+\`\`\`
+
+Schema
+
+\`\`\`jsx
+{
+  component: componentTypes.TEXT_FIELD,
+  name: 'shared_field',
+  label: 'Value of this field will be cleared after unmounting! Be aware!',
+  key: 1,
+  clearOnUnmount: true,
+  condition: {
+    when: 'something',
+    is: 'something',
+  },
+}, {
+  component: componentTypes.TEXT_FIELD,
+  name: 'shared_field',
+  label: 'Value of this field will be cleared after unmounting! Be aware!',
+  key: 2,
+  clearOnUnmount: true,
+  condition: {
+    when: 'something',
+    is: 'something else',
+  },
+}, {
+  component: componentTypes.TEXT_FIELD,
+  name: 'shared_field',
+  label: 'Value of this field will not be cleared after unmounting! Be aware!',
+  key: 3,
+  clearOnUnmount: false, // default value
+  condition: {
+    when: 'something',
+    is: 'something else and something',
+  },
+},
+\`\`\`
+
+
+`;
+
+export default <ReactMarkdown source={ text } />;

--- a/src/editor-demo/common/doc-texts/validators.js
+++ b/src/editor-demo/common/doc-texts/validators.js
@@ -1,12 +1,15 @@
 import React from 'react';
 import ReactMarkdown from '../md-helper';
+import TableOfContent, { headerToId } from '../helpers/list-of-content';
 
 const text = `
 You can validate a form by using of \`dataType\` or \`validate\`.
 
 DataTypes is used when you need validate only a data type of a value. For more complicated validators, you have to use validate.
 
-## dataType
+<a id="${headerToId('dataType')}" />
+
+### dataType
 
 You can specify a type of a component by providing \`dataType\`, which will automatically validates the component.
 
@@ -25,7 +28,9 @@ Currently, there are four types supported:
 ['integer', 'number', 'bool', 'string']
 \`\`\`
 
-### Overwriting deffault messages
+<a id="${headerToId('Overwriting default messages')}" />
+
+### Overwriting default messages
 
 Validators is a singleton. You can change its default messages:
 
@@ -60,7 +65,7 @@ Types of validators:
 ]
 \`\`\`
 
-## validate
+### validate
 
 You need to provide a \`validate\` array in the schema:
 
@@ -81,7 +86,9 @@ A item of the validate array is
 * a) object containing type and other specific values (see Default validators)
 * b) function
 
-### Default validators
+<a id="${headerToId('Default validators')}" />
+
+#### Default validators
 
 There are standard validators, which you can import from react-form-renderer package.
 
@@ -152,7 +159,9 @@ Validation functions are triggered only when field has a value with exception of
 
 Each validator type has additional configuration options in addition to custom error message.
 
-### Custom function
+<a id="${headerToId('Custom function')}" />
+
+#### Custom function
 
 As validator you can provide your custom function:
 
@@ -175,7 +184,9 @@ const isOdd = (value) => value % 2 === 0 ? undefined : 'Value is odd!';
 
 The function takes \`value\` as an argument and should return undefined when pasess or string as an error message when fails.
 
-### Async validator
+<a id="${headerToId('Async validator')}" />
+
+#### Async validator
 
 You can use a Async function as a validator. However, the returned promise will overwrite all other validators 
 (because it is returned last),
@@ -212,6 +223,7 @@ validate: [
 ...
 \`\`\`
 
+<a id="${headerToId('validateOnMount')}" />
 
 ### validateOnMount
 
@@ -233,4 +245,8 @@ By providing \`validateOnMount\` the validation will be triggered immediately af
 
 `;
 
-export default <ReactMarkdown source={ text } />;
+export default <React.Fragment>
+  <TableOfContent text= { text } />
+  <ReactMarkdown source={ text } />
+</React.Fragment>;
+

--- a/src/editor-demo/common/documenation-pages.js
+++ b/src/editor-demo/common/documenation-pages.js
@@ -5,6 +5,7 @@ import ComponentMappingText from './doc-texts/component-mapping';
 import Condition from './doc-texts/condition';
 import Validators from './doc-texts/validators';
 import FieldProvider from './doc-texts/field-provider';
+import Unmounting from './doc-texts/unmounting';
 
 export const docs = [{
   component: 'installation',
@@ -26,6 +27,10 @@ export const docs = [{
   component: 'conditions',
   linkText: 'Conditional fields',
   contentText: Condition,
+}, {
+  component: 'unmounting',
+  linkText: 'Clear On Unmount',
+  contentText: Unmounting,
 }, {
   component: 'validators',
   linkText: 'Validators',

--- a/src/editor-demo/common/examples-nav.js
+++ b/src/editor-demo/common/examples-nav.js
@@ -116,6 +116,14 @@ class Navigation extends Component  {
                 { this.renderExamplesItems('/others', otherExamples) }
               </List>
             </Collapse>
+            <ListItem
+              button
+              component={ props =>  <RouterLink to="/contribution" { ...props } /> }
+            >
+              <Typography variant="button" gutterBottom style={{ textTransform: 'capitalize', fontWeight: 'initial' }}>
+                Contribution
+              </Typography>
+            </ListItem>
           </List>
         </Drawer>
       </div>

--- a/src/editor-demo/common/helpers/list-of-content.js
+++ b/src/editor-demo/common/helpers/list-of-content.js
@@ -2,13 +2,14 @@ import React from 'react';
 import ReactMarkdown from '../md-helper';
 
 export default ({ text }) => {
-  const regex = /###(.*)/gm;
+  const regex = /^### (.*)/gm;
   const found = text.match(regex);
   return <React.Fragment>
     <ReactMarkdown source={ '### Table of content' }/>
     { found.map((header, index) => (
-      <ReactMarkdown key={ header } source={ `[${header.replace('###', '')}](#${header.replace('### ', '').replace(' ', '-').toLowerCase()})` }/>
+      <ReactMarkdown key={ header } source={ `[${header.replace('###', '')}](#${header.replace('### ', '').replace(/ /g, '-').toLowerCase()})` }/>
     )) }
+    <hr/>
   </React.Fragment>;
 };
 

--- a/src/editor-demo/common/helpers/list-of-content.js
+++ b/src/editor-demo/common/helpers/list-of-content.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import ReactMarkdown from '../md-helper';
+
+export default ({ text }) => {
+  const regex = /###(.*)/gm;
+  const found = text.match(regex);
+  return <React.Fragment>
+    <ReactMarkdown source={ '### Table of content' }/>
+    { found.map((header, index) => (
+      <ReactMarkdown key={ header } source={ `[${header.replace('###', '')}](#${header.replace('### ', '').replace(' ', '-').toLowerCase()})` }/>
+    )) }
+  </React.Fragment>;
+};
+

--- a/src/editor-demo/common/helpers/list-of-content.js
+++ b/src/editor-demo/common/helpers/list-of-content.js
@@ -1,13 +1,31 @@
 import React from 'react';
 import ReactMarkdown from '../md-helper';
 
+export const headerToId = (header) => header.replace('### ', '').replace(/ |\?|:/g, '-').toLowerCase();
+
+const subHeaders = (part) => {
+  const regex = /^#### (.*)/gm;
+  const found = part.match(regex);
+
+  return found && found.map((header) => (
+    <React.Fragment key={ header }>
+      <ReactMarkdown source={ `&nbsp;&nbsp;&nbsp;&nbsp;[${header.replace('####', '')}](${headerToId(header)})` }/>
+    </React.Fragment>
+  ));
+};
+
 export default ({ text }) => {
-  const regex = /^### (.*)/gm;
+  const regex = /^### .*/gm;
   const found = text.match(regex);
+  const parts = text.split(/^### .*/gm);
+
   return <React.Fragment>
-    <ReactMarkdown source={ '### Table of content' }/>
+    <ReactMarkdown source={ 'Content:' }/>
     { found.map((header, index) => (
-      <ReactMarkdown key={ header } source={ `[${header.replace('###', '')}](#${header.replace('### ', '').replace(/ /g, '-').toLowerCase()})` }/>
+      <React.Fragment key={ header }>
+        <ReactMarkdown source={ `&nbsp;&nbsp;[${header.replace('###', '')}](#${headerToId(header)})` }/>
+        { subHeaders(parts[index + 1]) }
+      </React.Fragment>
     )) }
     <hr/>
   </React.Fragment>;

--- a/src/editor-demo/common/other-text/manageiq-components.js
+++ b/src/editor-demo/common/other-text/manageiq-components.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import ReactMarkdown from '../md-helper';
+import TableOfContent from '../helpers/list-of-content';
 
 const text =  `
+<a id="duallist-select">
+
 ### Duallist select
 
 **Props**
@@ -81,7 +84,9 @@ By default, the value contains all options from the right side select. However, 
 
 **3** Then you can send values to endpoints/API!
 
-### \`<HR>\` component
+<a id="horizontal-rule">
+
+### Horizontal rule
 
 Just a \`hr\` component for using in forms.
 
@@ -93,4 +98,7 @@ Just a \`hr\` component for using in forms.
 \`\`\`
 `;
 
-export default <ReactMarkdown source={ text } />;
+export default <React.Fragment>
+  <TableOfContent text={ text } />
+  <ReactMarkdown source={ text } />
+</React.Fragment>;

--- a/src/editor-demo/pages/contribution.js
+++ b/src/editor-demo/pages/contribution.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import ReactMarkdown from '../common/md-helper';
+
+const text =  `
+### Contribution
+Please feel to free to contribute in any of Data-driven-forms repos!
+- 
+### Links to Github
+- a) [React form renderer](https://github.com/data-driven-forms/react-form-renderer)
+- b) [Patternfly 3 mapper](https://github.com/data-driven-forms/pf3-component-mapper)
+- c) [Patternfly 4 mapper](https://github.com/data-driven-forms/pf4-component-mapper)
+- d) [MaterialUI mapper](https://github.com/data-driven-forms/mui-component-mapper)
+- e) [Renderer demo](https://github.com/data-driven-forms/react-renderer-demo)
+
+- 
+### Links to NPM
+- a) [React form renderer](https://www.npmjs.com/package/@data-driven-forms/react-form-renderer)
+- b) [Patternfly 3 mapper](https://www.npmjs.com/package/@data-driven-forms/pf3-component-mapper)
+- c) [Patternfly 4 mapper](https://www.npmjs.com/package/@data-driven-forms/pf4-component-mapper)
+- d) [MaterialUI mapper](https://www.npmjs.com/package/@data-driven-forms/mui-component-mapper)
+`;
+
+export default () => <ReactMarkdown source={ text } />;


### PR DESCRIPTION
**Adds**

- clearOnUnmount doc page
- links to NPM in installation page
- contributioun page (right there are only githubs links, TODO: contribution guide)
- table of content support (table is generated automatically, a user just need to add anchors to the page, using `###` and `####` headers as two levels)
- tables of content in every longer page

Example:

![Screenshot from 2019-03-29 12-40-51](https://user-images.githubusercontent.com/32869456/55230362-ea4eb000-521f-11e9-81b3-3145c0445234.png)

