### PR TITLE
Automatically create anchor for headers

### DIFF
--- a/src/editor-demo/common/doc-texts/component-mapping.js
+++ b/src/editor-demo/common/doc-texts/component-mapping.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactMarkdown from '../md-helper';
 import { layoutComponents } from '@data-driven-forms/react-form-renderer';
-import TableOfContent, { headerToId } from '../helpers/list-of-content';
+import TableOfContent from '../helpers/list-of-content';
 
 const getTypes = (firstLine, apostrohpe = false) =>
   Object
@@ -15,8 +15,6 @@ We also understand that writing form components from the scratch might not be ve
 
 Form renderer requires two different mappers. Layout mapper and Form  FieldsMapper.
 
-<a id="${headerToId('Layout mapper')}" />
-
 ### Layout mapper
 Component inside this mapper influence the layout of the form. Now compared to the Form Fields mapper, we have to be very strict because we cannot define our own elements. Layout mapper must contain these types components:
 
@@ -28,8 +26,6 @@ ${ getTypes('const layoutComponents = {', true) }
 \`\`\`
 
 LayoutMapper is just good old javascript object with keys from layoutComponents, and the values are just React components:
-
-<a id="${headerToId('FormWrapper')}" />
 
 #### FormWrapper
 
@@ -51,8 +47,6 @@ const MyForm = () => (
 )
 \`\`\`
 
-<a id="${headerToId('Button')}" />
-
 #### Button
 Button component will be used for your submit, reset and cancel buttons.
 
@@ -72,8 +66,6 @@ const layoutMapper = {
 }
 \`\`\`
 
-<a id="${headerToId('Col')}" />
-
 #### Col
 Col represents wrapper arround one Form Field (hence the name Col). It does not have to mirror bootstrap Col, which is just the name we have decided to go with. If you for instance don't need any Col (or other wrapping) component, and you are handling this inside the actual Field component, you can use \`<React.Fragment>\` component. This way you will not create any element in your DOM. On the other hand, it might be usefull to implement it as a container for your components. Because we can't possibly create layout that suit 100% of our use cases, we can use this wrapper to pass additional styles to field components.
 
@@ -84,8 +76,6 @@ const Col = ({ children }) => (
   <div className="form-row">{children}</div>
 )
 \`\`\`
-
-<a id="${headerToId('FormGroup')}" />
 
 #### FormGroup
 
@@ -99,8 +89,6 @@ const FormGroup = ({ children }) => (
 )
 \`\`\`
 
-<a id="${headerToId('ButtonGroup')}" />
-
 #### ButtonGroup
 Wrapper for your form buttons
 
@@ -112,12 +100,8 @@ const ButtonGroup = ({ children }) => (
 )
 \`\`\`
 
-<a id="${headerToId('Icon, Array Field Wrapper, Help Block')}" />
-
 #### Icon, Array Field Wrapper, Help Block
 TO DO when array field docs are done
-
-<a id="${headerToId('Putting it all together')}" />
 
 #### Putting it all together
 
@@ -135,8 +119,6 @@ const MyForm = () => (
   />
 )
 \`\`\`
-
-<a id="${headerToId('Form Fields mapper')}" />
 
 ### Form Fields mapper
 
@@ -194,8 +176,6 @@ const schema = {
 }
 
 \`\`\`
-
-<a id="${headerToId('What about nesting?')}" />
 
 #### What about nesting?
 There might be a need to create something like a SubForm in your Forms. We made it possible, and there are two ways to do it.

--- a/src/editor-demo/common/doc-texts/condition.js
+++ b/src/editor-demo/common/doc-texts/condition.js
@@ -1,11 +1,10 @@
 import React from 'react';
 import ReactMarkdown from '../md-helper';
-import TableOfContent, { headerToId } from '../helpers/list-of-content';
+import TableOfContent from '../helpers/list-of-content';
 
 const text =  `
 You can show a field only if it meets a condition:
 
-<a id="${headerToId('Schema')}" />
 
 ### Schema
 
@@ -29,8 +28,6 @@ You can show a field only if it meets a condition:
 \`\`\`
 
 \`when\` - is name of field where the value is stored, **always required!**
-
-<a id="${headerToId('Conditions')}" />
 
 ### Conditions
 
@@ -118,8 +115,6 @@ condition: {
 
 // Foo = 'bar' => false
 \`\`\`
-
-<a id="${headerToId('Clearing values')}" />
 
 ### Clearing values
 

--- a/src/editor-demo/common/doc-texts/field-provider.js
+++ b/src/editor-demo/common/doc-texts/field-provider.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactMarkdown from '../md-helper';
-import TableOfContent, { headerToId } from '../helpers/list-of-content';
+import TableOfContent from '../helpers/list-of-content';
 
 const text = `
 React form renderer is using [react-final-form](https://github.com/final-form/react-final-form) for form state management.
@@ -12,8 +12,6 @@ FieldProvider is a wrapper component around standard
 [react-final-form Field component](https://github.com/final-form/react-final-form#field--reactcomponenttypefieldprops)
 which adds additional methods that will help you to control your form state.
 
-<a id="${headerToId('Accessing FieldProvider')}" />
-
 ### Accessing FieldProvider
 
 To use Fieldprovider, you first need to register a component to your component mapper.
@@ -22,8 +20,6 @@ You can read more about that in [Component mapping](/renderer/component-mapping)
 Each component will receive FieldProvider as a prop. Be aware that pre-defined component types are
 automatically wrapped in FieldProvider. This is done to make it easier to create component mappers for
 standard form components. List of standard components is avaiable [here](/renderer/form-schemas).
-
-<a id="${headerToId('Using FieldProvider')}" />
 
 ### Using FieldProvider
 
@@ -63,11 +59,7 @@ const NewComponent = ({ FieldProvider, formOptions, name ...rest }) => (
 export default NewComponent
 \`\`\`
 
-<a id="${headerToId('What are input and meta?')}" />
-
 ### What are input and meta?
-
-<a id="${headerToId('Input')}" />
 
 #### Input
 
@@ -85,8 +77,6 @@ Input is an object which contains methods that change form state. It contains th
 
 Every user interaction that updates field value in form state should also call \`input.onChange\` with correct value.
 
-<a id="${headerToId('Meta')}" />
-
 #### Meta
 
 Meta is a object which contains meta information about field with given name. There is a lot of information about every field.
@@ -100,8 +90,6 @@ Meta is a object which contains meta information about field with given name. Th
   valid: bool //true if this field has no validation or submission errors. false otherwise.
 }
 \`\`\`
-
-<a id="${headerToId('FormOptions')}" />
 
 ### FormOptions
 

--- a/src/editor-demo/common/doc-texts/form-schemas.js
+++ b/src/editor-demo/common/doc-texts/form-schemas.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactMarkdown from '../md-helper';
-import TableOfContent, { headerToId } from '../helpers/list-of-content';
+import TableOfContent from '../helpers/list-of-content';
 import { componentTypes } from '@data-driven-forms/react-form-renderer';
 
 const getTypes = () => Object.entries(componentTypes).reduce((acc, curr) => `${acc}\n  ${curr[0]}: '${curr[1]}',`,
@@ -13,8 +13,6 @@ With the intention to provide additional customization in the future. Currently 
 - Default-schema
 - ManageIQ schema
 - Mozilla json schema
-
-<a id="${headerToId('Default schema')}" />
 
 ### Default schema
 
@@ -54,8 +52,6 @@ const schema = {
 
 Example above shows definition of a very simple form with two form fields and a validation. We will now take a closer look at its attributes.
 
-<a id="${headerToId('default-schema-attributes')}" />
-
 #### default-schema-attributes
 
 |name|data type|
@@ -66,25 +62,17 @@ Example above shows definition of a very simple form with two form fields and a 
 
 Detailed descriptions of each attribute is below.
 
-<a id="${headerToId('title?: string')}" />
-
 #### title?: string
 
 Attribute defining form title.
-
-<a id="${headerToId('description?: string')}" />
 
 #### description?: string
 
 Attribute defining form description.
 
-<a id="${headerToId('fields: Array of Objects')}" />
-
 #### fields: Array of Objects
 
 Array that contains field definitions.
-
-<a id="${headerToId('Fields')}" />
 
 #### Fields
 
@@ -99,8 +87,6 @@ In human language, items of field array must be either objects, where each objec
 or array of objects, which are form fields as well. This rule allows the component to render all the fields in one cycle with minimal code branching.
 
 The structure of a single object is following:
-
-<a id="${headerToId('field attributes')}" />
 
 #### field attributes
 
@@ -137,8 +123,6 @@ const field = {
 Note that the field structure may vary based on your component implementation. There are few required attributes and most of 
 them do not have to match the given types. Most of them are based on used form components.
 
-<a id="${headerToId('component: string')}" />
-
 #### component: string
 
 Unique identifier of the component. Final component will be picked based on this key. There are several pre-defined constants 
@@ -155,19 +139,13 @@ componentTypes = {
 We are not limited by these component types. You can add your own type or use only few of them or combination of both. 
 More detailed explanation of how this impacts the rendered form [can be found here](#form-fields-mapper).
 
-<a id="${headerToId('name: string')}" />
-
 #### name: string
 
 This is traditional html5 name attribute for input elements.
 
-<a id="${headerToId('label')}" />
-
 #### label
 
 Label for form field. The type is based on your component definition.
-
-<a id="${headerToId('validate: Array? of Objects')}" />
 
 #### validate: Array? of Objects
 
@@ -247,8 +225,6 @@ const validate = [{
 \`\`\`
 Validation functions are triggered only when field has a value with exception of required validator.
 
-<a id="${headerToId('dataType: string?')}" />
-
 #### dataType: string?
 
 Adds field validation based on the value data type.
@@ -269,8 +245,6 @@ There are currently four defined data types:
 \`\`\`jsx
 ['integer', 'number', 'bool', 'string']
 \`\`\`
-
-<a id="${headerToId('assignFieldProvider: bool?')}" />
 
 #### assignFieldProvider: bool?
 
@@ -295,8 +269,6 @@ const wrappedComponents = [
 
 This wrapper will add necessary props to your component that will handle form state updates. It is reccomended to 
 read about field component in React Final Form docs. 
-
-<a id="${headerToId('condition: Object?')}" />
 
 #### condition: Object?
 
@@ -339,8 +311,6 @@ const fields = [{
 
 In example above, field \`Bar\` will appear when fields \`Foo\` value is \`Show bar field\`, \`true\`, \`123\` or \`Or now\`.
 
-<a id="${headerToId('Other attributes')}" />
-
 #### Other attributes
 
 Any other attributes will be passed to the component matching the \`component\` identifier.
@@ -369,8 +339,6 @@ const field = {
 
 Remember that the components define the interface. If your label is an image, pass the image source with isImage 
 flag maybe and handle rendering in the component.
-
-<a id="${headerToId('Field array and Fixed list')}" />
 
 ### Field array and Fixed list
 

--- a/src/editor-demo/common/doc-texts/validators.js
+++ b/src/editor-demo/common/doc-texts/validators.js
@@ -1,13 +1,11 @@
 import React from 'react';
 import ReactMarkdown from '../md-helper';
-import TableOfContent, { headerToId } from '../helpers/list-of-content';
+import TableOfContent from '../helpers/list-of-content';
 
 const text = `
 You can validate a form by using of \`dataType\` or \`validate\`.
 
 DataTypes is used when you need validate only a data type of a value. For more complicated validators, you have to use validate.
-
-<a id="${headerToId('dataType')}" />
 
 ### dataType
 
@@ -27,8 +25,6 @@ Currently, there are four types supported:
 \`\`\`jsx
 ['integer', 'number', 'bool', 'string']
 \`\`\`
-
-<a id="${headerToId('Overwriting default messages')}" />
 
 ### Overwriting default messages
 
@@ -85,8 +81,6 @@ You need to provide a \`validate\` array in the schema:
 A item of the validate array is 
 * a) object containing type and other specific values (see Default validators)
 * b) function
-
-<a id="${headerToId('Default validators')}" />
 
 #### Default validators
 
@@ -159,8 +153,6 @@ Validation functions are triggered only when field has a value with exception of
 
 Each validator type has additional configuration options in addition to custom error message.
 
-<a id="${headerToId('Custom function')}" />
-
 #### Custom function
 
 As validator you can provide your custom function:
@@ -183,8 +175,6 @@ const isOdd = (value) => value % 2 === 0 ? undefined : 'Value is odd!';
 \`\`\`
 
 The function takes \`value\` as an argument and should return undefined when pasess or string as an error message when fails.
-
-<a id="${headerToId('Async validator')}" />
 
 #### Async validator
 
@@ -222,8 +212,6 @@ validate: [
 ],
 ...
 \`\`\`
-
-<a id="${headerToId('validateOnMount')}" />
 
 ### validateOnMount
 

--- a/src/editor-demo/common/md-helper/index.js
+++ b/src/editor-demo/common/md-helper/index.js
@@ -12,6 +12,7 @@ import TableCell from '@material-ui/core/TableCell';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import Paper from '@material-ui/core/Paper';
+import { headerToId } from '../helpers/list-of-content';
 
 const renderers = {
   paragraph: ({ children }) => <Typography variant="body1" gutterBottom>{ children }</Typography>,
@@ -39,7 +40,10 @@ const renderers = {
       />
     </div>,
   link: ({ href, children }) => <Link href={ href }>{ children }</Link>,
-  heading: ({ level, children }) => <Typography variant={ `h${level + 2}` } style={{ marginBottom: 10, marginTop: 10 }}>{ children }</Typography>,
+  heading: ({ level, children }) => <React.Fragment>
+    <a id={ headerToId(children[0].props.value) } />
+    <Typography variant={ `h${level + 2}` } style={{ marginBottom: 10, marginTop: 10 }}>{ children }</Typography>
+  </React.Fragment>,
   list: ({ children }) => <List>{ children }</List>,
   listItem: ({ children }) =>
     <ListItem>

--- a/src/editor-demo/common/md-helper/index.js
+++ b/src/editor-demo/common/md-helper/index.js
@@ -13,6 +13,7 @@ import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import Paper from '@material-ui/core/Paper';
 import { headerToId } from '../helpers/list-of-content';
+import ShareButton from './share-button';
 
 const renderers = {
   paragraph: ({ children }) => <Typography variant="body1" gutterBottom>{ children }</Typography>,
@@ -42,7 +43,7 @@ const renderers = {
   link: ({ href, children }) => <Link href={ href }>{ children }</Link>,
   heading: ({ level, children }) => <React.Fragment>
     <a id={ headerToId(children[0].props.value) } />
-    <Typography variant={ `h${level + 2}` } style={{ marginBottom: 10, marginTop: 10 }}>{ children }</Typography>
+    <Typography variant={ `h${level + 2}` } style={{ marginBottom: 10, marginTop: 10 }}><ShareButton text={ headerToId(children[0].props.value) }/>{ children }</Typography>
   </React.Fragment>,
   list: ({ children }) => <List>{ children }</List>,
   listItem: ({ children }) =>

--- a/src/editor-demo/common/md-helper/share-button.js
+++ b/src/editor-demo/common/md-helper/share-button.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { CopyToClipboard } from 'react-copy-to-clipboard';
+import Button from '@material-ui/core/Button';
+import ClickAwayListener from '@material-ui/core/ClickAwayListener';
+import Tooltip from '@material-ui/core/Tooltip';
+import ShareIcon from '@material-ui/icons/Share';
+
+class ShareButton extends React.Component {
+    state = {
+      openTooltip: false,
+    }
+
+    handleTooltipClose = () => {
+      this.setState({ openTooltip: false });
+    }
+
+    handleTooltipOpen = () => {
+      this.setState({ openTooltip: true });
+    }
+
+    render() {
+      const { text } = this.props;
+      const { openTooltip } = this.state;
+
+      return <ClickAwayListener onClickAway={ this.handleTooltipClose }>
+        <Tooltip
+          PopperProps={{
+            disablePortal: true,
+          }}
+          onClose={ this.handleTooltipClose  }
+          open={ openTooltip }
+          disableFocusListener
+          disableHoverListener
+          disableTouchListener
+          title="Copied"
+        >
+          <CopyToClipboard text={ `${window.location.href.replace(/#.*/, '')}#${text}` } onCopy={ this.handleTooltipOpen }>
+            <Button size="small">
+              <ShareIcon fontSize="small" />
+            </Button>
+          </CopyToClipboard>
+        </Tooltip>
+      </ClickAwayListener>;
+    }
+}
+
+export default ShareButton;

--- a/src/editor-demo/common/other-text/manageiq-components.js
+++ b/src/editor-demo/common/other-text/manageiq-components.js
@@ -3,8 +3,6 @@ import ReactMarkdown from '../md-helper';
 import TableOfContent from '../helpers/list-of-content';
 
 const text =  `
-<a id="duallist-select">
-
 ### Duallist select
 
 **Props**
@@ -83,8 +81,6 @@ By default, the value contains all options from the right side select. However, 
 <br />
 
 **3** Then you can send values to endpoints/API!
-
-<a id="horizontal-rule">
 
 ### Horizontal rule
 


### PR DESCRIPTION
MD-HELPER **automatically** creates an anchor for every header, so we can create tables of content pretty easily with no manual work! 

And also this PR adds dedicated share button for every header, so we can easily **share** this to everyone!

![sharebutton](https://user-images.githubusercontent.com/32869456/55322502-d2c03300-547c-11e9-86d6-a7ed3e66651f.gif)

@Hyperkid123 

What do you think about making the table of contents sticky, e.g. as in https://jestjs.io/docs/en/getting-started#running-from-command-line or material-ui docs? 